### PR TITLE
Add AI Scan Bill Feature

### DIFF
--- a/HoneyDue.xcodeproj/project.pbxproj
+++ b/HoneyDue.xcodeproj/project.pbxproj
@@ -11,6 +11,15 @@
 		3A71912E2C23E548006F2516 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A71912D2C23E548006F2516 /* ContentView.swift */; };
 		3A7191302C23E549006F2516 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3A71912F2C23E549006F2516 /* Assets.xcassets */; };
 		3A7191332C23E549006F2516 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3A7191322C23E549006F2516 /* Preview Assets.xcassets */; };
+		E6C5263A2C23EB7300D3DCA0 /* ScanExpenseItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526372C23EB7300D3DCA0 /* ScanExpenseItem.swift */; };
+		E6C5263B2C23EB7300D3DCA0 /* ScanExpenseResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526382C23EB7300D3DCA0 /* ScanExpenseResult.swift */; };
+		E6C526432C23EB9200D3DCA0 /* ScanExpensePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5263E2C23EB9200D3DCA0 /* ScanExpensePage.swift */; };
+		E6C526442C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5263F2C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift */; };
+		E6C526482C23EBC300D3DCA0 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526452C23EBC300D3DCA0 /* CameraView.swift */; };
+		E6C526492C23EBC300D3DCA0 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526462C23EBC300D3DCA0 /* ImagePicker.swift */; };
+		E6C5264B2C23EC2400D3DCA0 /* LLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5264A2C23EC2400D3DCA0 /* LLMService.swift */; };
+		E6C5264D2C23EC2A00D3DCA0 /* DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5264C2C23EC2A00D3DCA0 /* DummyData.swift */; };
+		E6C526512C23EC9E00D3DCA0 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526502C23EC9E00D3DCA0 /* Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -19,6 +28,15 @@
 		3A71912D2C23E548006F2516 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3A71912F2C23E549006F2516 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3A7191322C23E549006F2516 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		E6C526372C23EB7300D3DCA0 /* ScanExpenseItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanExpenseItem.swift; sourceTree = "<group>"; };
+		E6C526382C23EB7300D3DCA0 /* ScanExpenseResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanExpenseResult.swift; sourceTree = "<group>"; };
+		E6C5263E2C23EB9200D3DCA0 /* ScanExpensePage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanExpensePage.swift; sourceTree = "<group>"; };
+		E6C5263F2C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanExpenseValidationPage.swift; sourceTree = "<group>"; };
+		E6C526452C23EBC300D3DCA0 /* CameraView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
+		E6C526462C23EBC300D3DCA0 /* ImagePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
+		E6C5264A2C23EC2400D3DCA0 /* LLMService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LLMService.swift; sourceTree = "<group>"; };
+		E6C5264C2C23EC2A00D3DCA0 /* DummyData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DummyData.swift; sourceTree = "<group>"; };
+		E6C526502C23EC9E00D3DCA0 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -51,10 +69,14 @@
 		3A71912A2C23E548006F2516 /* HoneyDue */ = {
 			isa = PBXGroup;
 			children = (
-				3A71912B2C23E548006F2516 /* HoneyDueApp.swift */,
-				3A71912D2C23E548006F2516 /* ContentView.swift */,
 				3A71912F2C23E549006F2516 /* Assets.xcassets */,
 				3A7191312C23E549006F2516 /* Preview Content */,
+				E6C5264F2C23EC7A00D3DCA0 /* Helpers */,
+				E6C526392C23EB7300D3DCA0 /* Model */,
+				E6C5264E2C23EC3400D3DCA0 /* Service */,
+				E6C526402C23EB9200D3DCA0 /* Screen */,
+				3A71912B2C23E548006F2516 /* HoneyDueApp.swift */,
+				3A71912D2C23E548006F2516 /* ContentView.swift */,
 			);
 			path = HoneyDue;
 			sourceTree = "<group>";
@@ -62,9 +84,54 @@
 		3A7191312C23E549006F2516 /* Preview Content */ = {
 			isa = PBXGroup;
 			children = (
+				E6C5264C2C23EC2A00D3DCA0 /* DummyData.swift */,
 				3A7191322C23E549006F2516 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		E6C526392C23EB7300D3DCA0 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				E6C526372C23EB7300D3DCA0 /* ScanExpenseItem.swift */,
+				E6C526382C23EB7300D3DCA0 /* ScanExpenseResult.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		E6C526402C23EB9200D3DCA0 /* Screen */ = {
+			isa = PBXGroup;
+			children = (
+				E6C5263E2C23EB9200D3DCA0 /* ScanExpensePage.swift */,
+				E6C5263F2C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift */,
+			);
+			path = Screen;
+			sourceTree = "<group>";
+		};
+		E6C526472C23EBC300D3DCA0 /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				E6C526452C23EBC300D3DCA0 /* CameraView.swift */,
+				E6C526462C23EBC300D3DCA0 /* ImagePicker.swift */,
+			);
+			path = UIKit;
+			sourceTree = "<group>";
+		};
+		E6C5264E2C23EC3400D3DCA0 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				E6C5264A2C23EC2400D3DCA0 /* LLMService.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
+		E6C5264F2C23EC7A00D3DCA0 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				E6C526502C23EC9E00D3DCA0 /* Extensions.swift */,
+				E6C526472C23EBC300D3DCA0 /* UIKit */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -137,8 +204,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6C526432C23EB9200D3DCA0 /* ScanExpensePage.swift in Sources */,
+				E6C526482C23EBC300D3DCA0 /* CameraView.swift in Sources */,
 				3A71912E2C23E548006F2516 /* ContentView.swift in Sources */,
 				3A71912C2C23E548006F2516 /* HoneyDueApp.swift in Sources */,
+				E6C5263B2C23EB7300D3DCA0 /* ScanExpenseResult.swift in Sources */,
+				E6C5264B2C23EC2400D3DCA0 /* LLMService.swift in Sources */,
+				E6C526492C23EBC300D3DCA0 /* ImagePicker.swift in Sources */,
+				E6C5263A2C23EB7300D3DCA0 /* ScanExpenseItem.swift in Sources */,
+				E6C5264D2C23EC2A00D3DCA0 /* DummyData.swift in Sources */,
+				E6C526512C23EC9E00D3DCA0 /* Extensions.swift in Sources */,
+				E6C526442C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HoneyDue.xcodeproj/project.pbxproj
+++ b/HoneyDue.xcodeproj/project.pbxproj
@@ -17,9 +17,11 @@
 		E6C526442C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5263F2C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift */; };
 		E6C526482C23EBC300D3DCA0 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526452C23EBC300D3DCA0 /* CameraView.swift */; };
 		E6C526492C23EBC300D3DCA0 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526462C23EBC300D3DCA0 /* ImagePicker.swift */; };
-		E6C5264B2C23EC2400D3DCA0 /* LLMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5264A2C23EC2400D3DCA0 /* LLMService.swift */; };
+		E6C5264B2C23EC2400D3DCA0 /* AIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5264A2C23EC2400D3DCA0 /* AIService.swift */; };
 		E6C5264D2C23EC2A00D3DCA0 /* DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5264C2C23EC2A00D3DCA0 /* DummyData.swift */; };
 		E6C526512C23EC9E00D3DCA0 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526502C23EC9E00D3DCA0 /* Extensions.swift */; };
+		E6C526542C244FA700D3DCA0 /* ScanExpenseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526532C244FA700D3DCA0 /* ScanExpenseViewModel.swift */; };
+		E6C526562C24584800D3DCA0 /* ScanExpenseReadingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C526552C24584800D3DCA0 /* ScanExpenseReadingPage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,9 +36,11 @@
 		E6C5263F2C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanExpenseValidationPage.swift; sourceTree = "<group>"; };
 		E6C526452C23EBC300D3DCA0 /* CameraView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		E6C526462C23EBC300D3DCA0 /* ImagePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
-		E6C5264A2C23EC2400D3DCA0 /* LLMService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LLMService.swift; sourceTree = "<group>"; };
+		E6C5264A2C23EC2400D3DCA0 /* AIService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		E6C5264C2C23EC2A00D3DCA0 /* DummyData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DummyData.swift; sourceTree = "<group>"; };
 		E6C526502C23EC9E00D3DCA0 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		E6C526532C244FA700D3DCA0 /* ScanExpenseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanExpenseViewModel.swift; sourceTree = "<group>"; };
+		E6C526552C24584800D3DCA0 /* ScanExpenseReadingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanExpenseReadingPage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +77,7 @@
 				3A7191312C23E549006F2516 /* Preview Content */,
 				E6C5264F2C23EC7A00D3DCA0 /* Helpers */,
 				E6C526392C23EB7300D3DCA0 /* Model */,
+				E6C526522C244F8400D3DCA0 /* ViewModel */,
 				E6C5264E2C23EC3400D3DCA0 /* Service */,
 				E6C526402C23EB9200D3DCA0 /* Screen */,
 				3A71912B2C23E548006F2516 /* HoneyDueApp.swift */,
@@ -103,6 +108,7 @@
 			isa = PBXGroup;
 			children = (
 				E6C5263E2C23EB9200D3DCA0 /* ScanExpensePage.swift */,
+				E6C526552C24584800D3DCA0 /* ScanExpenseReadingPage.swift */,
 				E6C5263F2C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift */,
 			);
 			path = Screen;
@@ -120,7 +126,7 @@
 		E6C5264E2C23EC3400D3DCA0 /* Service */ = {
 			isa = PBXGroup;
 			children = (
-				E6C5264A2C23EC2400D3DCA0 /* LLMService.swift */,
+				E6C5264A2C23EC2400D3DCA0 /* AIService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -132,6 +138,14 @@
 				E6C526472C23EBC300D3DCA0 /* UIKit */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		E6C526522C244F8400D3DCA0 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				E6C526532C244FA700D3DCA0 /* ScanExpenseViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -209,10 +223,12 @@
 				3A71912E2C23E548006F2516 /* ContentView.swift in Sources */,
 				3A71912C2C23E548006F2516 /* HoneyDueApp.swift in Sources */,
 				E6C5263B2C23EB7300D3DCA0 /* ScanExpenseResult.swift in Sources */,
-				E6C5264B2C23EC2400D3DCA0 /* LLMService.swift in Sources */,
+				E6C5264B2C23EC2400D3DCA0 /* AIService.swift in Sources */,
+				E6C526542C244FA700D3DCA0 /* ScanExpenseViewModel.swift in Sources */,
 				E6C526492C23EBC300D3DCA0 /* ImagePicker.swift in Sources */,
 				E6C5263A2C23EB7300D3DCA0 /* ScanExpenseItem.swift in Sources */,
 				E6C5264D2C23EC2A00D3DCA0 /* DummyData.swift in Sources */,
+				E6C526562C24584800D3DCA0 /* ScanExpenseReadingPage.swift in Sources */,
 				E6C526512C23EC9E00D3DCA0 /* Extensions.swift in Sources */,
 				E6C526442C23EB9200D3DCA0 /* ScanExpenseValidationPage.swift in Sources */,
 			);
@@ -356,6 +372,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -385,6 +402,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/HoneyDue/Assets.xcassets/ColorPrimary.colorset/Contents.json
+++ b/HoneyDue/Assets.xcassets/ColorPrimary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "extended-srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x92",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "extended-srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x92",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HoneyDue/Helpers/Extensions.swift
+++ b/HoneyDue/Helpers/Extensions.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 extension Double {
     func toIDRString() -> String {

--- a/HoneyDue/Helpers/Extensions.swift
+++ b/HoneyDue/Helpers/Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  Extensions.swift
+//  VisionAI
+//
+//  Created by Arya Adyatma on 19/06/24.
+//
+
+import Foundation
+
+extension Double {
+    func toIDRString() -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencySymbol = "Rp"
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: self))?.replacing(" ", with: "") ?? ""
+    }
+}

--- a/HoneyDue/Helpers/UIKit/CameraView.swift
+++ b/HoneyDue/Helpers/UIKit/CameraView.swift
@@ -1,0 +1,50 @@
+//
+//  CameraView.swift
+//  VisionAI
+//
+//  Created by on 15/05/24.
+//
+
+import SwiftUI
+
+import SwiftUI
+import AVFoundation
+
+struct CameraView: UIViewControllerRepresentable {
+    @Binding var isShowingCamera: Bool
+    @Binding var image: Image?
+    @Binding var uiImage: UIImage?
+    
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        var parent: CameraView
+        
+        init(parent: CameraView) {
+            self.parent = parent
+        }
+        
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let uiImage = info[.originalImage] as? UIImage {
+                parent.uiImage = uiImage
+                parent.image = Image(uiImage: uiImage)
+            }
+            parent.isShowingCamera = false
+        }
+        
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.isShowingCamera = false
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(parent: self)
+    }
+    
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.delegate = context.coordinator
+        picker.sourceType = .camera
+        return picker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+}

--- a/HoneyDue/Helpers/UIKit/ImagePicker.swift
+++ b/HoneyDue/Helpers/UIKit/ImagePicker.swift
@@ -1,0 +1,43 @@
+//
+//  ImagePicker.swift
+//  VisionAI
+//
+//  Created by Arya Adyatma on 12/06/24.
+//
+
+import SwiftUI
+
+struct ImagePicker: UIViewControllerRepresentable {
+    @Binding var image: Image?
+    @Binding var uiImage: UIImage?
+    
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.delegate = context.coordinator
+        picker.sourceType = .photoLibrary
+        return picker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: ImagePicker
+        
+        init(_ parent: ImagePicker) {
+            self.parent = parent
+        }
+        
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let uiImage = info[.originalImage] as? UIImage {
+                parent.uiImage = uiImage
+                parent.image = Image(uiImage: uiImage)
+            }
+            picker.dismiss(animated: true)
+        }
+    }
+}
+

--- a/HoneyDue/HoneyDueApp.swift
+++ b/HoneyDue/HoneyDueApp.swift
@@ -3,7 +3,6 @@
 //  HoneyDue
 //
 //  Created by Diki Dwi Diro on 20/06/24.
-//
 
 import SwiftUI
 

--- a/HoneyDue/Model/ScanExpenseItem.swift
+++ b/HoneyDue/Model/ScanExpenseItem.swift
@@ -1,0 +1,43 @@
+//
+//  TransactionItem.swift
+//  VisionAI
+//
+//  Created by Arya Adyatma on 12/06/24.
+//
+
+import Foundation
+
+struct ScanExpenseItem : Hashable, Codable, Identifiable {
+    var id: String
+    var name: String
+    var pricePerQtyIDR: Double
+    var qty: Double
+    var emoji: String
+    var notes: String
+    var taxRate: Double
+    var isSelected: Bool = true
+    
+    func getPricePerQtyIDR(includeTax: Bool) -> Double {
+        let price = includeTax ? pricePerQtyIDR * (1 + taxRate) : pricePerQtyIDR
+        return price
+    }
+    
+    func getPriceTimesQtyIDR(includeTax: Bool) -> Double {
+        let price = pricePerQtyIDR * qty
+        return includeTax ? price * (1 + taxRate) : price
+    }
+    
+    static func fromJsonArray(jsonString: String) -> [ScanExpenseItem] {
+        if let jsonData = jsonString.data(using: .utf8) {
+            do {
+                let expenseItems = try JSONDecoder().decode([ScanExpenseItem].self, from: jsonData)
+                return expenseItems
+            } catch {
+                print("Failed to decode JSON: \(error.localizedDescription)")
+            }
+        } else {
+            print("Failed to convert JSON string to Data")
+        }
+        return []
+    }
+}

--- a/HoneyDue/Model/ScanExpenseResult.swift
+++ b/HoneyDue/Model/ScanExpenseResult.swift
@@ -1,0 +1,46 @@
+//
+//  ScanBillResults.swift
+//  VisionAI
+//
+//  Created by Arya Adyatma on 16/06/24.
+//
+
+import Foundation
+
+struct ScanExpenseResult : Hashable, Codable, Identifiable {
+    
+    let id: String
+    var items: [ScanExpenseItem]
+    var taxChargeIDR: Double
+    var serviceChargeIDR: Double
+    var othersChargeIDR: Double
+    var discountsIDR: Double
+    var subtotalIDR: Double = 0
+    var totalIDR: Double = 0
+    
+    init(id: String, items: [ScanExpenseItem], taxChargeIDR: Double, serviceChargeIDR: Double, othersChargeIDR: Double, discountsIDR: Double) {
+        self.id = id
+        self.items = items
+        self.taxChargeIDR = taxChargeIDR
+        self.serviceChargeIDR = serviceChargeIDR
+        self.othersChargeIDR = othersChargeIDR
+        self.discountsIDR = discountsIDR
+        self.subtotalIDR = getSubtotalIDR(includeTax: false)
+        self.totalIDR = getTotalIDR()
+    }
+    
+    func getSubtotalIDR(includeTax: Bool) -> Double {
+        var subtotal = 0.0
+        for item in items {
+            subtotal += item.getPriceTimesQtyIDR(includeTax: includeTax)
+        }
+        return subtotal
+    }
+    
+    func getTotalIDR() -> Double {
+        let subtotal = getSubtotalIDR(includeTax: false)
+        let total = subtotal + taxChargeIDR + serviceChargeIDR + othersChargeIDR - discountsIDR
+        return total
+    }
+    
+}

--- a/HoneyDue/Preview Content/DummyData.swift
+++ b/HoneyDue/Preview Content/DummyData.swift
@@ -1,0 +1,27 @@
+//
+//  DummyData.swift
+//  VisionAI
+//
+//  Created by Arya Adyatma on 19/06/24.
+//
+
+import Foundation
+
+extension ScanExpenseResult {
+    static func getExample() -> ScanExpenseResult {
+        let items = [
+            ScanExpenseItem(id: "1", name: "Iced Sweet Lychee Tea", pricePerQtyIDR: 25000, qty: 2, emoji: "🍹", notes: "", taxRate: 0.1),
+            ScanExpenseItem(id: "2", name: "Choco Motive", pricePerQtyIDR: 10000, qty: 2, emoji: "🍫", notes: "", taxRate: 0.1),
+            ScanExpenseItem(id: "3", name: "Red", pricePerQtyIDR: 15000, qty: 2, emoji: "🍷", notes: "", taxRate: 0.1),
+            ScanExpenseItem(id: "4", name: "Black", pricePerQtyIDR: 12000, qty: 1, emoji: "☕️", notes: "", taxRate: 0.1)
+        ]
+        return ScanExpenseResult(
+            id: "example1",
+            items: items,
+            taxChargeIDR: 11200,
+            serviceChargeIDR: 5000,
+            othersChargeIDR: 0,
+            discountsIDR: 0
+        )
+    }
+}

--- a/HoneyDue/Screen/ScanExpensePage.swift
+++ b/HoneyDue/Screen/ScanExpensePage.swift
@@ -18,7 +18,7 @@ struct ScanExpensePage: View {
     @State private var expenses: [ScanExpenseItem] = []
     @State private var navigateToBillResults = false
     
-    @ObservedObject var viewModel = LLMService(
+    @ObservedObject var viewModel = AIService(
         identifier: FakeAPIKey.expenseScanner.rawValue,
         useStreaming: false,
         isConversation: false
@@ -32,7 +32,7 @@ struct ScanExpensePage: View {
             VStack {
                 ZStack {
                     Circle()
-                        .foregroundColor(/*@START_MENU_TOKEN@*/.blue/*@END_MENU_TOKEN@*/)
+                        .foregroundColor(Color("ColorPrimary"))
                         .opacity(0.2)
                         .frame(width: 64, height: 64)
                     Text("🤑")
@@ -52,7 +52,7 @@ struct ScanExpensePage: View {
                         }) {
                             Text("Take Photo")
                                 .padding()
-                                .background(Color.blue)
+                                .background(Color("ColorPrimary"))
                                 .foregroundColor(.white)
                                 .cornerRadius(10)
                         }
@@ -62,7 +62,7 @@ struct ScanExpensePage: View {
                         }) {
                             Text("Select Photo")
                                 .padding()
-                                .background(Color.blue)
+                                .background(Color("ColorPrimary"))
                                 .foregroundColor(.white)
                                 .cornerRadius(10)
                         }

--- a/HoneyDue/Screen/ScanExpensePage.swift
+++ b/HoneyDue/Screen/ScanExpensePage.swift
@@ -1,0 +1,121 @@
+//
+//  ScanBillPage.swift
+//  VisionAI
+//
+//  Created by Arya Adyatma on 12/06/24.
+//
+
+import SwiftUI
+
+struct ScanExpensePage: View {
+    @State private var isShowingCamera = false
+    @State private var isShowingPhotoLibrary = false
+    @State private var image: Image? = nil
+    @State private var uiImage: UIImage? = nil
+    @State private var responseText: String = ""
+    @State private var isLoading = false
+    @State private var question: String = "Scan this."
+    @State private var expenses: [ScanExpenseItem] = []
+    @State private var navigateToBillResults = false
+    
+    @ObservedObject var viewModel = LLMService(
+        identifier: FakeAPIKey.expenseScanner.rawValue,
+        useStreaming: false,
+        isConversation: false
+    )
+    
+    var body: some View {
+        Group {
+//            NavigationLink(destination: ScanExpenseResultPage(expenses: expenses), isActive: $navigateToBillResults) {
+//                EmptyView()
+//            }
+            VStack {
+                ZStack {
+                    Circle()
+                        .foregroundColor(/*@START_MENU_TOKEN@*/.blue/*@END_MENU_TOKEN@*/)
+                        .opacity(0.2)
+                        .frame(width: 64, height: 64)
+                    Text("🤑")
+                        .scaleEffect(1.6)
+                }
+                Text("**Bill Scanner AI**")
+                    .font(.title)
+                
+                Text("Feel the magic of AI to automate your expense tracking 🚀")
+                    .padding()
+                    .padding(.horizontal)
+            
+                if !isLoading {
+                    HStack {
+                        Button(action: {
+                            isShowingCamera = true
+                        }) {
+                            Text("Take Photo")
+                                .padding()
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(10)
+                        }
+                        
+                        Button(action: {
+                            isShowingPhotoLibrary = true
+                        }) {
+                            Text("Select Photo")
+                                .padding()
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(10)
+                        }
+                    }
+                }
+
+                if isLoading {
+                    ProgressView()
+                        .padding()
+                }
+                ScrollView {
+                    Text(responseText)
+                        .background(.gray.opacity(0.1))
+                }
+                
+            }
+            .padding()
+            .sheet(isPresented: $isShowingCamera) {
+                CameraView(isShowingCamera: $isShowingCamera, image: $image, uiImage: $uiImage)
+            }
+            .sheet(isPresented: $isShowingPhotoLibrary) {
+                ImagePicker(image: $image, uiImage: $uiImage)
+            }
+            .onChange(of: uiImage) {
+                askVisionAI()
+            }
+            .onChange(of: expenses) {
+                navigateToBillResults = true
+            }
+        }
+    }
+    
+    func askVisionAI() {
+        guard let uiImage = uiImage else { return }
+        isLoading = true
+        
+        viewModel.sendMessage(query: question, uiImage: uiImage) { result in
+            DispatchQueue.main.async {
+                self.isLoading = false
+                switch result {
+                case .success(let response):
+                    self.responseText = response
+                    expenses = ScanExpenseItem.fromJsonArray(jsonString: response)
+                case .failure(let error):
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+    
+}
+
+
+#Preview {
+    ScanExpensePage()
+}

--- a/HoneyDue/Screen/ScanExpenseReadingPage.swift
+++ b/HoneyDue/Screen/ScanExpenseReadingPage.swift
@@ -1,0 +1,87 @@
+//
+//  ScanExpenseReadingPage.swift
+//  HoneyDue
+//
+//  Created by Arya Adyatma on 20/06/24.
+//
+
+import SwiftUI
+
+struct ScanExpenseReadingPage: View {
+    @State private var progress: Double = 0.5
+    @State private var isBouncing = false
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            
+            Image(systemName: "magnifyingglass")
+                .resizable()
+                .frame(width: 50, height: 50)
+                .foregroundColor(.gray)
+                .padding(.bottom, 10)
+                .offset(y: isBouncing ? -5 : 5)
+                .animation(
+                    Animation.easeInOut(duration: 0.5)
+                        .repeatForever(autoreverses: true)
+                )
+                .onAppear {
+                    isBouncing = true
+                }
+            
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .frame(width: 200, height: 6)
+                    .foregroundColor(Color.gray.opacity(0.5))
+                    .cornerRadius(8)
+                
+                VStack {
+                    Capsule()
+                        .frame(width: 100, height: 6)
+                        .foregroundColor(.gray)
+                        .offset(x: progress)
+                        .animation(
+                            Animation.linear(duration: 2)
+                                .repeatForever(autoreverses: false)
+                    )
+                }
+                .offset(x: -125)
+                
+            }
+            .onAppear {
+                progress = 350
+            }
+            .clipped()
+            .cornerRadius(8)
+            .padding(20)
+            
+            
+            Text("Reading the bill")
+                .font(.headline)
+                .padding(.bottom, 5)
+            
+            Text("Please wait")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+                .padding(.bottom, 20)
+            
+            Button(action: {
+                // Add your cancel action here
+            }) {
+                Text("Cancel")
+                    .font(.headline)
+                    .frame(width: 100, height: 40)
+                    .background(Color(UIColor.systemGray5))
+                    .foregroundColor(.gray)
+                    .cornerRadius(10)
+            }
+            
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ScanExpenseReadingPage()
+}

--- a/HoneyDue/Screen/ScanExpenseValidationPage.swift
+++ b/HoneyDue/Screen/ScanExpenseValidationPage.swift
@@ -1,0 +1,189 @@
+//
+//  ScanBillResults.swift
+//  VisionAI
+//
+//  Created by Arya Adyatma on 12/06/24.
+//
+
+import SwiftUI
+
+struct ScanExpenseValidationPage: View {
+    @State var expenseResult: ScanExpenseResult = ScanExpenseResult.getExample()
+    @State private var isEditing: Bool = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("Scan Bill Results")
+                    .font(.title)
+                    .fontWeight(.bold)
+                Text("This is the scanned result. Make sure to check that the items were scanned correctly.")
+                    .fontWeight(.medium)
+                    .opacity(0.3)
+                
+                Group {
+                    VStack(spacing: 16) {
+                        ForEach(expenseResult.items.indices, id: \.self) { index in
+                            ExpenseItemView(item: $expenseResult.items[index], isEditing: $isEditing)
+                        }
+                    }
+                    .padding(.vertical)
+                }
+                .background(.white)
+                .cornerRadius(16)
+                .padding(.top)
+                
+//                HStack {
+//                    Text("You scanned bill includes tax amount. We adjusted your item price to match after tax.")
+//                        .font(.callout)
+//                        .foregroundStyle(.green)
+//                        .fontWeight(.semibold)
+//                        .padding()
+//                    Spacer()
+//                }
+//                .background(.green.opacity(0.2))
+//                .cornerRadius(16)
+                
+                Group {
+                    VStack {
+                        ReceiptView(nameText: "Subtotal", priceText: Binding.constant(expenseResult.getSubtotalIDR(includeTax: false)), isEditing: Binding.constant(false))
+                        ReceiptView(nameText: "Tax", priceText: $expenseResult.taxChargeIDR, isEditing: $isEditing)
+                        ReceiptView(nameText: "Service Charge", priceText: $expenseResult.serviceChargeIDR, isEditing: $isEditing)
+                        ReceiptView(nameText: "Discounts", priceText: $expenseResult.discountsIDR, isEditing: $isEditing)
+                        ReceiptView(nameText: "Others", priceText: $expenseResult.othersChargeIDR, isEditing: $isEditing)
+                        ReceiptView(nameText: "Total Amount", priceText: Binding.constant(expenseResult.getTotalIDR()), isEditing: Binding.constant(false))
+                    }
+                    .padding(.vertical, 8)
+                }
+                .background(.white)
+                .cornerRadius(16)
+                .padding(.top)
+                
+                HStack {
+                    Spacer()
+                    Button(action: {
+                        isEditing.toggle()
+                    }) {
+                        Text(isEditing ? "Finish Edit Bill" : "Edit Bill")
+                    }
+                }
+                
+                Button(action: {
+                    // Action here
+                }) {
+                    Text("Confirm Bill")
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.blue)
+                        .cornerRadius(16)
+                }
+                .background(Color(UIColor.systemGray6))
+                .edgesIgnoringSafeArea(.all)
+                .padding(.top)
+                
+                Spacer()
+            }
+            .padding()
+        }
+        .background(Color.black.opacity(0.05).edgesIgnoringSafeArea(.all))
+    }
+}
+struct ExpenseItemView: View {
+    @Binding var item: ScanExpenseItem
+    @Binding var isEditing: Bool
+    
+    var body: some View {
+        HStack {
+            ZStack {
+                Rectangle()
+                    .foregroundStyle(.blue)
+                    .opacity(0.2)
+                    .frame(width: 48, height: 48)
+                    .cornerRadius(16)
+                Text(item.emoji)
+                    .scaleEffect(1.5)
+            }
+            .padding(.leading)
+            .padding(.trailing, 5)
+            
+            VStack(alignment: .leading) {
+                if isEditing {
+                    TextField("Name", text: $item.name)
+                        .fontWeight(.bold)
+                        .opacity(0.9)
+                        .textFieldStyle(BlueUnderlineTextFieldStyle())
+                } else {
+                    Text(item.name)
+                        .fontWeight(.bold)
+                        .opacity(0.9)
+                }
+                
+                HStack {
+                    if isEditing {
+                        TextField("Price", value: $item.pricePerQtyIDR, format: .number)
+                            .opacity(0.6)
+                            .textFieldStyle(BlueUnderlineTextFieldStyle())
+                    } else {
+                        Text(item.getPricePerQtyIDR(includeTax: false).toIDRString())
+                            .opacity(0.6)
+                    }
+                    Spacer()
+                    if isEditing {
+                        TextField("Quantity", value: $item.qty, format: .number)
+                            .opacity(0.6)
+                            .textFieldStyle(BlueUnderlineTextFieldStyle())
+                            .frame(width: 50)
+                    } else {
+                        Text("x\(Int(item.qty))")
+                            .opacity(0.6)
+                    }
+                    Spacer()
+                    Text(item.getPriceTimesQtyIDR(includeTax: false).toIDRString())
+                        .fontWeight(.bold)
+                }
+            }
+            .padding(.trailing)
+        }
+    }
+}
+
+struct BlueUnderlineTextFieldStyle: TextFieldStyle {
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+            .padding(.bottom, 2)
+            .overlay(Rectangle().frame(height: 1).foregroundColor(.blue), alignment: .bottom)
+    }
+}
+
+struct ReceiptView: View {
+    var nameText: String
+    @Binding var priceText: Double
+    @Binding var isEditing: Bool
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Text(nameText)
+                Spacer()
+                if isEditing {
+                    TextField("Price", value: $priceText, format: .number)
+                        .keyboardType(.decimalPad)
+                        .multilineTextAlignment(.trailing)
+                        .textFieldStyle(BlueUnderlineTextFieldStyle())
+                        .frame(width: 80)
+                } else {
+                    Text(priceText, format: .number)
+                        .fontWeight(.bold)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 4)
+        }
+    }
+}
+
+#Preview {
+    ScanExpenseValidationPage()
+}

--- a/HoneyDue/Screen/ScanExpenseValidationPage.swift
+++ b/HoneyDue/Screen/ScanExpenseValidationPage.swift
@@ -14,9 +14,14 @@ struct ScanExpenseValidationPage: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
-                Text("Scan Bill Results")
-                    .font(.title)
-                    .fontWeight(.bold)
+                HStack {
+                    Spacer()
+                    Text("Your Receipt")
+                        .font(.title)
+                        .fontWeight(.semibold)
+                    Spacer()
+                }
+                .padding(.bottom, 5)
                 Text("This is the scanned result. Make sure to check that the items were scanned correctly.")
                     .fontWeight(.medium)
                     .opacity(0.3)
@@ -25,13 +30,14 @@ struct ScanExpenseValidationPage: View {
                     VStack(spacing: 16) {
                         ForEach(expenseResult.items.indices, id: \.self) { index in
                             ExpenseItemView(item: $expenseResult.items[index], isEditing: $isEditing)
+                            Rectangle()
+                                .frame(height: 1)
+                                .opacity(0.1)
                         }
                     }
                     .padding(.vertical)
                 }
-                .background(.white)
-                .cornerRadius(16)
-                .padding(.top)
+                .padding(.top, 2)
                 
 //                HStack {
 //                    Text("You scanned bill includes tax amount. We adjusted your item price to match after tax.")
@@ -57,7 +63,7 @@ struct ScanExpenseValidationPage: View {
                 }
                 .background(.white)
                 .cornerRadius(16)
-                .padding(.top)
+                .padding(.top, 2)
                 
                 HStack {
                     Spacer()
@@ -65,6 +71,7 @@ struct ScanExpenseValidationPage: View {
                         isEditing.toggle()
                     }) {
                         Text(isEditing ? "Finish Edit Bill" : "Edit Bill")
+                            .foregroundStyle(Color("ColorPrimary"))
                     }
                 }
                 
@@ -76,7 +83,7 @@ struct ScanExpenseValidationPage: View {
                         .foregroundColor(.white)
                         .padding()
                         .frame(maxWidth: .infinity)
-                        .background(Color.blue)
+                        .background(Color("ColorPrimary"))
                         .cornerRadius(16)
                 }
                 .background(Color(UIColor.systemGray6))
@@ -87,33 +94,35 @@ struct ScanExpenseValidationPage: View {
             }
             .padding()
         }
-        .background(Color.black.opacity(0.05).edgesIgnoringSafeArea(.all))
+//        .background(Color.black.opacity(0.05).edgesIgnoringSafeArea(.all))
     }
 }
 struct ExpenseItemView: View {
     @Binding var item: ScanExpenseItem
     @Binding var isEditing: Bool
+    var showIcon: Bool = false
     
     var body: some View {
         HStack {
-            ZStack {
-                Rectangle()
-                    .foregroundStyle(.blue)
-                    .opacity(0.2)
-                    .frame(width: 48, height: 48)
-                    .cornerRadius(16)
-                Text(item.emoji)
-                    .scaleEffect(1.5)
+            if showIcon {
+                ZStack {
+                    Rectangle()
+                        .foregroundStyle(.blue)
+                        .opacity(0.2)
+                        .frame(width: 48, height: 48)
+                        .cornerRadius(16)
+                    Text(item.emoji)
+                        .scaleEffect(1.5)
+                }
+                .padding(.trailing, 5)
             }
-            .padding(.leading)
-            .padding(.trailing, 5)
             
             VStack(alignment: .leading) {
                 if isEditing {
                     TextField("Name", text: $item.name)
                         .fontWeight(.bold)
                         .opacity(0.9)
-                        .textFieldStyle(BlueUnderlineTextFieldStyle())
+                        .textFieldStyle(CustomTextFieldStyle())
                 } else {
                     Text(item.name)
                         .fontWeight(.bold)
@@ -124,7 +133,7 @@ struct ExpenseItemView: View {
                     if isEditing {
                         TextField("Price", value: $item.pricePerQtyIDR, format: .number)
                             .opacity(0.6)
-                            .textFieldStyle(BlueUnderlineTextFieldStyle())
+                            .textFieldStyle(CustomTextFieldStyle())
                     } else {
                         Text(item.getPricePerQtyIDR(includeTax: false).toIDRString())
                             .opacity(0.6)
@@ -133,7 +142,7 @@ struct ExpenseItemView: View {
                     if isEditing {
                         TextField("Quantity", value: $item.qty, format: .number)
                             .opacity(0.6)
-                            .textFieldStyle(BlueUnderlineTextFieldStyle())
+                            .textFieldStyle(CustomTextFieldStyle())
                             .frame(width: 50)
                     } else {
                         Text("x\(Int(item.qty))")
@@ -144,16 +153,18 @@ struct ExpenseItemView: View {
                         .fontWeight(.bold)
                 }
             }
-            .padding(.trailing)
         }
     }
 }
 
-struct BlueUnderlineTextFieldStyle: TextFieldStyle {
+struct CustomTextFieldStyle: TextFieldStyle {
     func _body(configuration: TextField<Self._Label>) -> some View {
         configuration
-            .padding(.bottom, 2)
-            .overlay(Rectangle().frame(height: 1).foregroundColor(.blue), alignment: .bottom)
+            .padding(.horizontal, 4)
+            .overlay(
+                RoundedRectangle(cornerRadius: 3)
+                    .stroke(Color(.black).opacity(0.2), lineWidth: 1)
+            )
     }
 }
 
@@ -170,15 +181,15 @@ struct ReceiptView: View {
                 if isEditing {
                     TextField("Price", value: $priceText, format: .number)
                         .keyboardType(.decimalPad)
+                        .fontWeight(.bold)
                         .multilineTextAlignment(.trailing)
-                        .textFieldStyle(BlueUnderlineTextFieldStyle())
+                        .textFieldStyle(CustomTextFieldStyle())
                         .frame(width: 80)
                 } else {
                     Text(priceText, format: .number)
                         .fontWeight(.bold)
                 }
             }
-            .padding(.horizontal)
             .padding(.vertical, 4)
         }
     }

--- a/HoneyDue/Service/LLMService.swift
+++ b/HoneyDue/Service/LLMService.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Combine
+import UIKit
+
+enum FakeAPIKey: String {
+    case GPT4o = "app-nZejRKIvCLCPLae2pxNTUESN"
+    case expenseScanner = "app-czUwKirJvIP44SsjT0wxRTfk"
+}
+
+class LLMService: ObservableObject {
+    var llmIdentifier: String
+    var useStreaming: Bool
+    var isConversation: Bool
+    
+    init(identifier: String, useStreaming: Bool, isConversation: Bool) {
+        self.llmIdentifier = identifier
+        self.useStreaming = useStreaming
+        self.isConversation = isConversation
+    }
+    
+    @Published var response: String = ""
+    
+    private var cancellables = Set<AnyCancellable>()
+    private var conversationId = ""
+    
+    func sendMessage(query: String, uiImage: UIImage?, completion: @escaping (Result<String, Error>) -> Void) {
+        response = ""
+        
+        if let image = uiImage {
+            uploadImage(image: image) { result in
+                switch result {
+                case .success(let fileId):
+                    self.sendChatMessage(query: query, fileId: fileId, completion: completion)
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+        } else {
+            sendChatMessage(query: query, fileId: nil, completion: completion)
+        }
+    }
+    
+    private func sendChatMessage(query: String, fileId: String?, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let url = URL(string: "https://api.dify.ai/v1/chat-messages") else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(llmIdentifier)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        var files: [[String: Any]] = []
+        if let fileId = fileId {
+            files.append([
+                "type": "image",
+                "transfer_method": "local_file",
+                "upload_file_id": fileId
+            ])
+        }
+        
+        let body: [String: Any] = [
+            "inputs": [:],
+            "query": query,
+            "response_mode": "blocking",
+            "conversation_id": conversationId,
+            "user": "abc-123",
+            "files": files
+        ]
+        
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            
+            guard let data = data else {
+                completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])))
+                return
+            }
+            
+            do {
+                let blockingResponse = try JSONDecoder().decode(LLMBlockingResponse.self, from: data)
+                self.handleBlockingResponse(blockingResponse)
+                completion(.success(self.response))
+            } catch {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+    
+    private func uploadImage(image: UIImage, completion: @escaping (Result<String, Error>) -> Void) {
+        guard let url = URL(string: "https://api.dify.ai/v1/files/upload") else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(llmIdentifier)", forHTTPHeaderField: "Authorization")
+        
+        let boundary = UUID().uuidString
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        
+        let maxSize = 1 * 1024 * 1024 // 1 MB
+        let resizedImage = resizeImage(image: image, maxSize: maxSize) ?? image
+        guard let imageData = resizedImage.jpegData(compressionQuality: 0.8) else { return }
+        
+        var body = Data()
+        
+        // Append file data
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"image.jpg\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        body.append(imageData)
+        body.append("\r\n".data(using: .utf8)!)
+        
+        // Append user data
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"user\"\r\n\r\n".data(using: .utf8)!)
+        body.append("abc-123\r\n".data(using: .utf8)!)
+        
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        
+        request.httpBody = body
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            
+            guard let data = data else {
+                completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "No data received"])))
+                return
+            }
+            
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                   let fileId = json["id"] as? String {
+                    completion(.success(fileId))
+                } else {
+                    completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON format"])))
+                }
+            } catch {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+    
+    private func resizeImage(image: UIImage, maxSize: Int) -> UIImage? {
+        var resizedImage = image
+        let compression: CGFloat = 0.8
+        guard var imageData = resizedImage.jpegData(compressionQuality: compression) else { return nil }
+        
+        while imageData.count > maxSize {
+            let newSize = CGSize(width: resizedImage.size.width * 0.95, height: resizedImage.size.height * 0.95)
+            UIGraphicsBeginImageContext(newSize)
+            resizedImage.draw(in: CGRect(origin: .zero, size: newSize))
+            resizedImage = UIGraphicsGetImageFromCurrentImageContext() ?? resizedImage
+            UIGraphicsEndImageContext()
+            
+            if let newImageData = resizedImage.jpegData(compressionQuality: compression) {
+                imageData = newImageData
+            }
+        }
+        
+        return resizedImage
+    }
+    
+    private func handleBlockingResponse(_ blockingResponse: LLMBlockingResponse) {
+        if blockingResponse.event == "message" {
+            response += blockingResponse.answer ?? ""
+        }
+        if conversationId.isEmpty && isConversation {
+            conversationId = blockingResponse.conversation_id ?? ""
+        }
+    }
+    
+    func resetConversation() {
+        conversationId = ""
+    }
+}
+
+// Define the blocking response model
+struct LLMBlockingResponse: Decodable {
+    let event: String
+    let message_id: String?
+    let conversation_id: String?
+    let answer: String?
+    let created_at: Int?
+}

--- a/HoneyDue/ViewModel/ScanExpenseViewModel.swift
+++ b/HoneyDue/ViewModel/ScanExpenseViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  ScanBillViewModel.swift
+//  HoneyDue
+//
+//  Created by Arya Adyatma on 20/06/24.
+//
+
+import Foundation


### PR DESCRIPTION
# Add AI Scan Bill Feature

**New Service:**
- LLMService - A wrapper to call various AI LLM services such as OpenAI, Google Gemini, and Meta LLaMA. Supports Vision LLM.

**New Screens:**
- ScanExpensePage - SwiftUI view that let user to take photo of a bill, then the AI will parse it.
- ScanExpenseValidationPage - SwiftUI view that shows the result of expense items from AI scan.

**New Models:**
- ScanExpenseResult - The GPT generated schema to parse the scanned item. This object includes a list of ScanExpenseItem so we can calculate subtotal, and taxes.
- ScanExpenseItem - Represents a single expense item based on scanned item.
